### PR TITLE
Add robust Stop & Shop scraper

### DIFF
--- a/scrapers/stopandshop.js
+++ b/scrapers/stopandshop.js
@@ -1,13 +1,34 @@
 export function scrapeStopAndShop() {
   const products = [];
-  const tiles = document.querySelectorAll('[data-testid="product-tile"], .product-tile');
-  tiles.forEach(tile => {
-    const name = tile.querySelector('[data-testid="product-name"], .product-name')?.textContent?.trim() || '';
-    const price = tile.querySelector('[data-testid="product-price"], .product-price')?.textContent?.trim() || '';
-    const unit = tile.querySelector('[data-testid="product-unit"], .product-unit')?.textContent?.trim() || '';
-    const image = tile.querySelector('img')?.src || '';
-    if (name && price) {
-      products.push({ name, price, unit, image });
+  document.querySelectorAll('[data-testid="product-tile"]').forEach(tile => {
+    const name = tile.querySelector('[data-testid="product-title"]')?.innerText?.trim();
+
+    const priceText = tile.querySelector('.product-pricing__sale-price')?.innerText?.trim() ||
+      tile.querySelector('.product-pricing__price')?.innerText?.trim() ||
+      tile.querySelector('.product-pricing')?.textContent?.match(/\$[0-9.,]+/)?.[0];
+
+    const perUnitText = tile.querySelector('.product-pricing__price-per-unit')?.innerText?.trim();
+    const image = tile.querySelector('.product-image__img')?.src || tile.querySelector('img')?.src || '';
+
+    let unitQty = null;
+    let unitType = null;
+    if (perUnitText) {
+      const match = perUnitText.match(/\$([\d.]+)\/([a-zA-Z]+)/);
+      if (match) {
+        unitQty = parseFloat(match[1]);
+        unitType = match[2];
+      }
+    }
+
+    if (name && priceText) {
+      products.push({
+        name,
+        price: priceText,
+        unit: perUnitText || '',
+        unitQty,
+        unitType,
+        image
+      });
     }
   });
   return products;


### PR DESCRIPTION
## Summary
- improve the Stop & Shop scraper to parse modern product tiles
- capture product title, price, per-unit text, unit quantity, unit type and image

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c5306ccb48329968821cdf915d4cf