### PR TITLE
Fix import module error in content script

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
   "content_scripts": [
     {
       "matches": ["https://stopandshop.com/*"],
-      "js": ["contentScript.js"]
+      "js": ["contentScript.js"],
+      "type": "module"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- load `contentScript.js` as a module so ES module imports work

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c5774a6748329a8e645c1f5ab1f3a