### PR TITLE
Display scraped product images

### DIFF
--- a/item.html
+++ b/item.html
@@ -7,6 +7,7 @@
     body { font-family: Arial, sans-serif; width: 300px; }
     .store { border-bottom: 1px solid #ccc; margin-bottom: 10px; padding-bottom: 5px; }
     .product-list { margin-top: 5px; }
+    .product img { width: 200px; height: 200px; object-fit: contain; background: #ccc; display: block; }
   </style>
 </head>
 <body>

--- a/item.js
+++ b/item.js
@@ -4,6 +4,10 @@ import { pricePerUnit } from './utils/priceComparer.js';
 
 const STORE_SELECTION_PATH = 'Required for grocery app/store_selection_stopandshop.json';
 
+// Grey placeholder used until real product images load
+const PLACEHOLDER_IMG =
+  "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><rect width='100%' height='100%' fill='%23ccc'/></svg>";
+
 function key(type, item, store) {
   return `${type}_${encodeURIComponent(item)}_${encodeURIComponent(store)}`;
 }
@@ -55,16 +59,30 @@ async function saveFinal(item, store) {
 
 function createProductOption(prod, onSelect) {
   const wrap = document.createElement('div');
+  wrap.className = 'product';
+
+  const img = document.createElement('img');
+  img.src = prod.image || PLACEHOLDER_IMG;
+  img.width = 200;
+  img.height = 200;
+  img.alt = prod.name;
+  img.onerror = () => {
+    img.src = PLACEHOLDER_IMG;
+  };
+  wrap.appendChild(img);
+
+  const span = document.createElement('span');
+  span.textContent = prod.name;
+  wrap.appendChild(span);
+
   const btn = document.createElement('button');
   let priceStr = prod.priceNumber != null ? `$${prod.priceNumber.toFixed(2)}` : prod.price;
   let qtyStr = prod.convertedQty != null ? `${prod.convertedQty.toFixed(2)} oz` : prod.size;
   let unitStr = prod.pricePerUnit != null ? `$${prod.pricePerUnit.toFixed(2)}/oz` : prod.unit;
   btn.textContent = `Select (${priceStr} - ${qtyStr} - ${unitStr})`;
   btn.addEventListener('click', () => onSelect(prod));
-  const span = document.createElement('span');
-  span.textContent = prod.name;
-  wrap.appendChild(span);
   wrap.appendChild(btn);
+
   return wrap;
 }
 

--- a/scrapeResults.html
+++ b/scrapeResults.html
@@ -6,6 +6,7 @@
   <style>
     body { font-family: Arial, sans-serif; width: 300px; }
     .product { margin-bottom: 5px; }
+    .product img { width: 200px; height: 200px; object-fit: contain; background: #ccc; display: block; }
   </style>
 </head>
 <body>

--- a/scrapeResults.js
+++ b/scrapeResults.js
@@ -23,6 +23,9 @@ const store = params.get('store');
 const title = document.getElementById('title');
 const container = document.getElementById('products');
 
+const PLACEHOLDER_IMG =
+  "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><rect width='100%' height='100%' fill='%23ccc'/></svg>";
+
 title.textContent = `${item} - ${store}`;
 
 loadProducts(item, store).then(products => {
@@ -33,10 +36,24 @@ loadProducts(item, store).then(products => {
   products.forEach(prod => {
     const div = document.createElement('div');
     div.className = 'product';
+
+    const img = document.createElement('img');
+    img.src = prod.image || PLACEHOLDER_IMG;
+    img.width = 200;
+    img.height = 200;
+    img.alt = prod.name;
+    img.onerror = () => {
+      img.src = PLACEHOLDER_IMG;
+    };
+    div.appendChild(img);
+
     let pStr = prod.priceNumber != null ? `$${prod.priceNumber.toFixed(2)}` : prod.price;
     let qStr = prod.convertedQty != null ? `${prod.convertedQty.toFixed(2)} oz` : prod.size;
     let uStr = prod.pricePerUnit != null ? `$${prod.pricePerUnit.toFixed(2)}/oz` : prod.unit;
-    div.textContent = `${prod.name} - ${pStr} - ${qStr} - ${uStr}`;
+    const info = document.createElement('span');
+    info.textContent = `${prod.name} - ${pStr} - ${qStr} - ${uStr}`;
+    div.appendChild(info);
+
     const btn = document.createElement('button');
     btn.textContent = 'Select';
     btn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- show thumbnail images for products in `item.html` and `scrapeResults.html`
- load a grey placeholder image when the product image is unavailable

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c6e344978832988ba2b8c2da64e05