### PR TITLE
Fix Walmart search link encoding

### DIFF
--- a/item.js
+++ b/item.js
@@ -126,9 +126,13 @@ async function init() {
     const openBtn = document.createElement('button');
     openBtn.textContent = entry.store;
     openBtn.addEventListener('click', () => {
+      let link = entry.link;
+      if (entry.store === 'Walmart') {
+        link = link.replace(/%2B/g, '+');
+      }
       chrome.runtime.sendMessage({
         type: 'openStoreTab',
-        url: entry.link,
+        url: link,
         item: itemName,
         store: entry.store
       }, response => {


### PR DESCRIPTION
## Summary
- decode `%2B` in Walmart search URLs when opening store tabs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d477d076483298463574e7dea0a9b