### PR TITLE
Handle Walmart unit-of-measure with explicit quantity

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -159,10 +159,13 @@ function scrapeWalmart() {
     const perUnitText = tile.querySelector('.gray')?.innerText?.trim();
     let pricePerUnit = null;
     let unitType = null;
-    const match = perUnitText?.match(/\$([\d.]+)\/(\w+)/);
+    const match = perUnitText?.match(/\$([\d.]+)\/?\s*([\d.]*)\s*(\w+)/);
     if (match) {
-      pricePerUnit = parseFloat(match[1]);
-      unitType = match[2].toLowerCase();
+      let priceVal = parseFloat(match[1]);
+      const qtyVal = parseFloat(match[2]);
+      const qty = !isNaN(qtyVal) && qtyVal !== 0 ? qtyVal : 1;
+      pricePerUnit = priceVal / qty;
+      unitType = match[3].toLowerCase();
       const factor = UNIT_FACTORS[unitType];
       if (factor) {
         pricePerUnit = pricePerUnit / factor;

--- a/scrapers/walmart.js
+++ b/scrapers/walmart.js
@@ -42,10 +42,13 @@ export function scrapeWalmart() {
     const perUnitText = tile.querySelector('.gray')?.innerText?.trim();
     let pricePerUnit = null;
     let unitType = null;
-    const match = perUnitText?.match(/\$([\d.]+)\/(\w+)/);
+    const match = perUnitText?.match(/\$([\d.]+)\/?\s*([\d.]*)\s*(\w+)/);
     if (match) {
-      pricePerUnit = parseFloat(match[1]);
-      unitType = match[2].toLowerCase();
+      let priceVal = parseFloat(match[1]);
+      const qtyVal = parseFloat(match[2]);
+      const qty = !isNaN(qtyVal) && qtyVal !== 0 ? qtyVal : 1;
+      pricePerUnit = priceVal / qty;
+      unitType = match[3].toLowerCase();
       const factor = UNIT_FACTORS[unitType];
       if (factor) {
         pricePerUnit = pricePerUnit / factor;


### PR DESCRIPTION
## Summary
- refine Walmart scraper logic
- parse quantity from unit of measure like `$4.96 / 100ct`
- update injected content script with the same calculation

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d50fb89b883298c6543ee6de614d7