### PR TITLE
Implement pack detection for Walmart results

### DIFF
--- a/scrapers/walmart.js
+++ b/scrapers/walmart.js
@@ -37,22 +37,50 @@ export function scrapeWalmart() {
   const tiles = document.querySelectorAll('[data-testid="list-view"] > div');
   tiles.forEach((tile, i) => {
     const name = tile.querySelector('[data-automation-id="product-title"]')?.innerText?.trim();
+    const packMatch = name?.match(/(\d+)\s*pack/i);
+    const packCount = packMatch ? parseInt(packMatch[1], 10) : 1;
     const priceMatch = tile.querySelector('[data-automation-id="product-price"]')?.innerText?.match(/\$?\d+\.\d{2}/);
     const price = priceMatch ? priceMatch[0] : null;
     const perUnitText = tile.querySelector('.gray')?.innerText?.trim();
     let pricePerUnit = null;
     let unitType = null;
-    const match = perUnitText?.match(/\$([\d.]+)\/?\s*([\d.]*)\s*(\w+)/);
-    if (match) {
-      let priceVal = parseFloat(match[1]);
-      const qtyVal = parseFloat(match[2]);
-      const qty = !isNaN(qtyVal) && qtyVal !== 0 ? qtyVal : 1;
-      pricePerUnit = priceVal / qty;
-      unitType = match[3].toLowerCase();
-      const factor = UNIT_FACTORS[unitType];
+    let sizeQty = null;
+    let sizeUnit = null;
+    let convertedQty = null;
+
+    const sizeMatch = name?.match(/(\d+(?:\.\d+)?)\s*(fl\s*oz|oz|lb|g|kg|ml|l|ct)/i);
+    if (sizeMatch) {
+      sizeQty = parseFloat(sizeMatch[1]);
+      sizeUnit = sizeMatch[2].replace(/\s+/g, '');
+      if (packCount > 1) {
+        sizeQty = sizeQty / packCount;
+      }
+      const factor = UNIT_FACTORS[sizeUnit.toLowerCase()];
       if (factor) {
-        pricePerUnit = pricePerUnit / factor;
+        convertedQty = sizeQty * factor;
         unitType = 'oz';
+        if (price) {
+          const p = parseFloat(price.replace(/[^0-9.]/g, ''));
+          if (!isNaN(p)) {
+            pricePerUnit = p / (convertedQty * packCount);
+          }
+        }
+      }
+    }
+
+    if (pricePerUnit == null) {
+      const match = perUnitText?.match(/\$([\d.]+)\/?\s*([\d.]*)\s*(\w+)/);
+      if (match) {
+        let priceVal = parseFloat(match[1]);
+        const qtyVal = parseFloat(match[2]);
+        const qty = !isNaN(qtyVal) && qtyVal !== 0 ? qtyVal : 1;
+        pricePerUnit = priceVal / qty;
+        unitType = match[3].toLowerCase();
+        const factor = UNIT_FACTORS[unitType];
+        if (factor) {
+          pricePerUnit = pricePerUnit / factor;
+          unitType = 'oz';
+        }
       }
     }
     const image = tile.querySelector('img[data-testid="productTileImage"]')?.src || '';
@@ -67,12 +95,12 @@ export function scrapeWalmart() {
         price,
         priceNumber,
         size: '',
-        sizeQty: null,
-        sizeUnit: null,
+        sizeQty,
+        sizeUnit,
         unit: perUnitText || '',
         unitQty: null,
         unitType,
-        convertedQty: null,
+        convertedQty,
         pricePerUnit,
         image
       });


### PR DESCRIPTION
## Summary
- detect pack counts in Walmart product names
- adjust size quantity per pack when pack count present
- compute price per unit based on adjusted quantity

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d53fcac848329ba1cd114347a990d