### PR TITLE
Filter products by item name in results

### DIFF
--- a/item.js
+++ b/item.js
@@ -57,6 +57,15 @@ async function saveFinal(item, store) {
   await setStorage({ [k]: store });
 }
 
+function nameMatchesProduct(productName, itemName) {
+  const itemWords = itemName
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+  const prod = productName.toLowerCase();
+  return itemWords.some(w => prod.includes(w));
+}
+
 function createProductOption(prod, onSelect) {
   const wrap = document.createElement('div');
   wrap.className = 'product';
@@ -88,13 +97,15 @@ function createProductOption(prod, onSelect) {
 
 function addProductList(div, store, products, info, itemName) {
   if (!products || products.length === 0) return;
+  const filtered = products.filter(p => nameMatchesProduct(p.name, itemName));
+  if (filtered.length === 0) return;
   // Remove existing list if any
   const existing = div.querySelector('.product-list');
   if (existing) existing.remove();
   const list = document.createElement('div');
   list.className = 'product-list';
 
-  const sorted = [...products].sort((a, b) => {
+  const sorted = [...filtered].sort((a, b) => {
     const aPrice = a.pricePerUnit ?? Infinity;
     const bPrice = b.pricePerUnit ?? Infinity;
     return aPrice - bPrice;

--- a/scrapeResults.js
+++ b/scrapeResults.js
@@ -16,6 +16,15 @@ function saveSelected(item, store, product) {
   });
 }
 
+function nameMatchesProduct(productName, itemName) {
+  const itemWords = itemName
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+  const prod = productName.toLowerCase();
+  return itemWords.some(w => prod.includes(w));
+}
+
 const params = new URLSearchParams(location.search);
 const item = params.get('item');
 const store = params.get('store');
@@ -29,12 +38,13 @@ const PLACEHOLDER_IMG =
 title.textContent = `${item} - ${store}`;
 
 loadProducts(item, store).then(products => {
-  if (products.length === 0) {
+  const filtered = products.filter(p => nameMatchesProduct(p.name, item));
+  if (filtered.length === 0) {
     container.textContent = 'No products found.';
     return;
   }
 
-  const sorted = [...products].sort((a, b) => {
+  const sorted = [...filtered].sort((a, b) => {
     const aPrice = a.pricePerUnit ?? Infinity;
     const bPrice = b.pricePerUnit ?? Infinity;
     return aPrice - bPrice;


### PR DESCRIPTION
## Summary
- filter store product lists before displaying
- only show products that share at least one word with the item name

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d5eceeaec83299307804ef193bd12