### PR TITLE
Fix selection update from results popup

### DIFF
--- a/scrapeResults.js
+++ b/scrapeResults.js
@@ -75,13 +75,18 @@ loadProducts(item, store).then(products => {
     btn.textContent = 'Select';
     btn.addEventListener('click', async () => {
       await saveSelected(item, store, prod);
-      chrome.runtime.sendMessage({
-        type: 'selectedItem',
-        item,
-        store,
-        product: prod
-      });
-      window.close();
+      chrome.runtime.sendMessage(
+        {
+          type: 'selectedItem',
+          item,
+          store,
+          product: prod
+        },
+        () => {
+          // Close only after the message is sent
+          window.close();
+        }
+      );
     });
     div.appendChild(document.createElement('br'));
     div.appendChild(btn);


### PR DESCRIPTION
## Summary
- ensure results selection closes only after messaging the item popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d695c55e08329ae296ecb6923b440