### PR TITLE
Add final selection button next to each store

### DIFF
--- a/item.html
+++ b/item.html
@@ -21,7 +21,6 @@
   <button id="back">Back</button>
   <h1 id="itemName"></h1>
   <div id="stores"></div>
-  <div id="final"></div>
   <script type="module" src="item.js"></script>
 </body>
 </html>

--- a/item.js
+++ b/item.js
@@ -107,6 +107,20 @@ async function init() {
       }, 1000);
     });
     header.appendChild(scrapeBtn);
+
+    const finalBtn = document.createElement('button');
+    finalBtn.textContent = 'Final Selection';
+    finalBtn.style.display = 'none';
+    finalBtn.addEventListener('click', async () => {
+      await saveFinal(itemName, entry.store);
+      chrome.runtime.sendMessage({
+        type: 'finalSelection',
+        item: itemName,
+        store: entry.store
+      });
+      window.close();
+    });
+    header.appendChild(finalBtn);
     div.appendChild(header);
 
     const info = document.createElement('div');
@@ -134,32 +148,16 @@ async function init() {
       img.src = selected.image || PLACEHOLDER_IMG;
       img.alt = selected.name;
       img.style.display = 'block';
+      finalBtn.style.display = 'inline';
     }
 
     // Previously scraped results are no longer shown in this window
 
     storesContainer.appendChild(div);
-    storeMap.set(entry.store, { div, info, img, tabId: null });
+    storeMap.set(entry.store, { div, info, img, tabId: null, finalBtn });
   }
 
-  const finalDiv = document.getElementById('final');
-  const finalHeader = document.createElement('h2');
-  finalHeader.textContent = 'Final Selection';
-  finalDiv.appendChild(finalHeader);
-  const finalInfo = document.createElement('div');
-  const currentFinal = await loadFinal(itemName);
-  finalInfo.textContent = currentFinal ? `Selected store: ${currentFinal}` : 'None';
-  finalDiv.appendChild(finalInfo);
-  const chooseBtn = document.createElement('button');
-  chooseBtn.textContent = 'Choose Store';
-  chooseBtn.addEventListener('click', async () => {
-    const store = prompt('Enter store name exactly as above:');
-    if (store) {
-      await saveFinal(itemName, store);
-      finalInfo.textContent = `Selected store: ${store}`;
-    }
-  });
-  finalDiv.appendChild(chooseBtn);
+
 
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.type === 'selectedItem' && message.item === itemName) {
@@ -182,6 +180,7 @@ async function init() {
         rec.img.src = selected.image || PLACEHOLDER_IMG;
         rec.img.alt = selected.name;
         rec.img.style.display = 'block';
+        rec.finalBtn.style.display = 'inline';
       }
     }
   });

--- a/popup.js
+++ b/popup.js
@@ -18,6 +18,8 @@ async function getData() {
   return { needs, selections, consumption, stock, expiration };
 }
 
+const finalMap = new Map();
+
 function getFinal(itemName) {
   const key = `final_${encodeURIComponent(itemName)}`;
   return new Promise(resolve => {
@@ -51,6 +53,7 @@ async function init() {
       }
     });
     li.appendChild(finalSpan);
+    finalMap.set(item.name, finalSpan);
     itemsContainer.appendChild(li);
   });
 }
@@ -62,5 +65,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'scrapedData') {
     console.log('Received data for', message.item);
     console.log(message.products);
+  } else if (message.type === 'finalSelection') {
+    const span = finalMap.get(message.item);
+    if (span) {
+      span.textContent = ` - ${message.store}`;
+    }
   }
 });


### PR DESCRIPTION
## Summary
- add Final Selection button for each store in `item.html`
- show button once a product is selected
- notify popup and save the final store when selected
- update popup to handle final selection messages and show selected store

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d741cd85c83299b8bb6e7e3ae634d