### PR TITLE
Add Amazon scraper

### DIFF
--- a/Required for grocery app/store_links_base.csv
+++ b/Required for grocery app/store_links_base.csv
@@ -1,3 +1,4 @@
 Store Name,Base Search URL
 Stop & Shop,https://stopandshop.com/product-search/
 Walmart,https://www.walmart.com/search?q=%7C%7Cexclude_oos%3AShow+available+items+only
+Amazon,https://www.amazon.com/s?k=

--- a/Required for grocery app/store_selection_stopandshop.json
+++ b/Required for grocery app/store_selection_stopandshop.json
@@ -2734,5 +2734,1373 @@
     "pricePerUnit": null,
     "link": "https://www.walmart.com/search?q=Yoo-hoo%2BChocolate%2BDrink&facet=fulfillment_method_in_store%3AIn-store%7C%7Cexclude_oos%3AShow+available+items+only",
     "image": null
+  },
+  {
+    "name": "Air Fryer Vegetables Seasoned Frozen Foods",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Air+Fryer+Vegetables+Seasoned+Frozen+Foods",
+    "image": null
+  },
+  {
+    "name": "Bagels 6 count Bakery & Bread",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Bagels+6+count+Bakery+%26+Bread",
+    "image": null
+  },
+  {
+    "name": "Bags Freezer",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Bags+Freezer",
+    "image": null
+  },
+  {
+    "name": "Bags Quart",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Bags+Quart",
+    "image": null
+  },
+  {
+    "name": "Kraft Macaroni & Cheese Original Flavor Packaged Meals",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Kraft+Macaroni+%26+Cheese+Original+Flavor+Packaged+Meals",
+    "image": null
+  },
+  {
+    "name": "Minute Rice White Side Dishes",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Minute+Rice+White+Side+Dishes",
+    "image": null
+  },
+  {
+    "name": "Cream of Wheat Instant Maple Brown Sugar Breakfast Cereals",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Cream+of+Wheat+Instant+Maple+Brown+Sugar+Breakfast+Cereals",
+    "image": null
+  },
+  {
+    "name": "Bread Sandwich Bakery & Bread",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Bread+Sandwich+Bakery+%26+Bread",
+    "image": null
+  },
+  {
+    "name": "Pedigree DentaStix  Pet Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Pedigree+DentaStix+Pet+Supplies",
+    "image": null
+  },
+  {
+    "name": "Cilantro  Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Cilantro+Produce",
+    "image": null
+  },
+  {
+    "name": "Brown Sugar  Baking & Cooking",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Brown+Sugar+Baking+%26+Cooking",
+    "image": null
+  },
+  {
+    "name": "Bob Evans Macaroni & Cheese  Packaged Meals",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Bob+Evans+Macaroni+%26+Cheese+Packaged+Meals",
+    "image": null
+  },
+  {
+    "name": "Cheese Shredded Cheddar Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Cheese+Shredded+Cheddar+Dairy",
+    "image": null
+  },
+  {
+    "name": "Purell Hand Sanitizer  Health & Beauty",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Purell+Hand+Sanitizer+Health+%26+Beauty",
+    "image": null
+  },
+  {
+    "name": "Cheese White Sharp, Shredded Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Cheese+White+Sharp%2C+Shredded+Dairy",
+    "image": null
+  },
+  {
+    "name": "Beef Strip Steak Meat",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Beef+Strip+Steak+Meat",
+    "image": null
+  },
+  {
+    "name": "Cottage Cheese Small Curd Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Cottage+Cheese+Small+Curd+Dairy",
+    "image": null
+  },
+  {
+    "name": "Flour  Baking & Cooking",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Flour+Baking+%26+Cooking",
+    "image": null
+  },
+  {
+    "name": "Bell Peppers  Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Bell+Peppers+Produce",
+    "image": null
+  },
+  {
+    "name": "Garlic  Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Garlic+Produce",
+    "image": null
+  },
+  {
+    "name": "Ginger  Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Ginger+Produce",
+    "image": null
+  },
+  {
+    "name": "Cheese Muenster, Sliced Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Cheese+Muenster%2C+Sliced+Dairy",
+    "image": null
+  },
+  {
+    "name": "Heavy Cream  Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Heavy+Cream+Dairy",
+    "image": null
+  },
+  {
+    "name": "Cheese String Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Cheese+String+Dairy",
+    "image": null
+  },
+  {
+    "name": "Ground Beef Angus Sirloin Meat",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Ground+Beef+Angus+Sirloin+Meat",
+    "image": null
+  },
+  {
+    "name": "Kale  Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Kale+Produce",
+    "image": null
+  },
+  {
+    "name": "Lime Juice  Beverages",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Lime+Juice+Beverages",
+    "image": null
+  },
+  {
+    "name": "Milk Gallon 1 Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Milk+Gallon+1+Dairy",
+    "image": null
+  },
+  {
+    "name": "Mushrooms Shiitake Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Mushrooms+Shiitake+Produce",
+    "image": null
+  },
+  {
+    "name": "Imitation Crab  Seafood",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Imitation+Crab+Seafood",
+    "image": null
+  },
+  {
+    "name": "Paper Bowl 20 oz",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Paper+Bowl+20+oz",
+    "image": null
+  },
+  {
+    "name": "Paper Plate Everyday 10.06",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Paper+Plate+Everyday+10.06",
+    "image": null
+  },
+  {
+    "name": "Paper Plate Everyday 6.87",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Paper+Plate+Everyday+6.87",
+    "image": null
+  },
+  {
+    "name": "Potatoes Baby Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Potatoes+Baby+Produce",
+    "image": null
+  },
+  {
+    "name": "Pet Treats Pill Pockets Pet Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Pet+Treats+Pill+Pockets+Pet+Supplies",
+    "image": null
+  },
+  {
+    "name": "Sausage Sweet Meat",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Sausage+Sweet+Meat",
+    "image": null
+  },
+  {
+    "name": "Potatoes Red Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Potatoes+Red+Produce",
+    "image": null
+  },
+  {
+    "name": "Potatoes Russet Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Potatoes+Russet+Produce",
+    "image": null
+  },
+  {
+    "name": "Potatoes Yams Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Potatoes+Yams+Produce",
+    "image": null
+  },
+  {
+    "name": "Pretzel Frozen Frozen Foods",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Pretzel+Frozen+Frozen+Foods",
+    "image": null
+  },
+  {
+    "name": "Sugar Snap Peas  Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Sugar+Snap+Peas+Produce",
+    "image": null
+  },
+  {
+    "name": "Sriracha Hot Chili Sauce,  Condiments Sauces",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Sriracha+Hot+Chili+Sauce%2C+Condiments+Sauces",
+    "image": null
+  },
+  {
+    "name": "Birds Eye Skillet Meals  Frozen Foods",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Birds+Eye+Skillet+Meals+Frozen+Foods",
+    "image": null
+  },
+  {
+    "name": "Tortillas  Bakery & Bread",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Tortillas+Bakery+%26+Bread",
+    "image": null
+  },
+  {
+    "name": "Aleia's Bread Crumbs Italian, Gluten Free Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Aleia's+Bread+Crumbs+Italian%2C+Gluten+Free+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Argo Corn Starch 100 Pure Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Argo+Corn+Starch+100+Pure+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Arm & Hammer Baking Soda Pure Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Arm+%26+Hammer+Baking+Soda+Pure+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Barilla Pasta Fettuccine Pasta",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Barilla+Pasta+Fettuccine+Pasta",
+    "image": null
+  },
+  {
+    "name": "Bertolli Vinegar Balsamic Vinegars",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Bertolli+Vinegar+Balsamic+Vinegars",
+    "image": null
+  },
+  {
+    "name": "Betty Crocker Cookie Mix Snickerdoodle Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Betty+Crocker+Cookie+Mix+Snickerdoodle+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Charmin Toilet Paper Strong",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Charmin+Toilet+Paper+Strong",
+    "image": null
+  },
+  {
+    "name": "Foxy Romaine Hearts  Fresh Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Foxy+Romaine+Hearts+Fresh+Produce",
+    "image": null
+  },
+  {
+    "name": "Botticelli Pasta Sauce Traditional Premium Pasta Sauce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Botticelli+Pasta+Sauce+Traditional+Premium+Pasta+Sauce",
+    "image": null
+  },
+  {
+    "name": "Bounty Paper Towels",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Bounty+Paper+Towels",
+    "image": null
+  },
+  {
+    "name": "Bragg Apple Cider Vinegar Organic Vinegars",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Bragg+Apple+Cider+Vinegar+Organic+Vinegars",
+    "image": null
+  },
+  {
+    "name": "Bumble Bee Canned Tuna Albacore Light Canned Seafood",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Bumble+Bee+Canned+Tuna+Albacore+Light+Canned+Seafood",
+    "image": null
+  },
+  {
+    "name": "Cabot Butter Salted Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Cabot+Butter+Salted+Dairy",
+    "image": null
+  },
+  {
+    "name": "Campbell's Soup Chicken Noodle Soup",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Campbell's+Soup+Chicken+Noodle+Soup",
+    "image": null
+  },
+  {
+    "name": "Cape Cod Chips",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Cape+Cod+Chips",
+    "image": null
+  },
+  {
+    "name": "Cascade Dishwasher Detergent Platinum",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Cascade+Dishwasher+Detergent+Platinum",
+    "image": null
+  },
+  {
+    "name": "Gold Peak Tea Zero Sugar Beverages",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Gold+Peak+Tea+Zero+Sugar+Beverages",
+    "image": null
+  },
+  {
+    "name": "Cheerios Cereal Strawberry Banana Breakfast Cereals",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Cheerios+Cereal+Strawberry+Banana+Breakfast+Cereals",
+    "image": null
+  },
+  {
+    "name": "Chex Cereal Corn Breakfast Cereals",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Chex+Cereal+Corn+Breakfast+Cereals",
+    "image": null
+  },
+  {
+    "name": "Chips Ahoy Cookies Chocolate Chip Snacks",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Chips+Ahoy+Cookies+Chocolate+Chip+Snacks",
+    "image": null
+  },
+  {
+    "name": "Chosen Foods Oil Organic Avocado, Coconut & Safflower Cooking Oils",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Chosen+Foods+Oil+Organic+Avocado%2C+Coconut+%26+Safflower+Cooking+Oils",
+    "image": null
+  },
+  {
+    "name": "Coffee-mate Iced Coffee French Vanilla Beverages",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Coffee-mate+Iced+Coffee+French+Vanilla+Beverages",
+    "image": null
+  },
+  {
+    "name": "Heinz Ketchup Tomato Condiments",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Heinz+Ketchup+Tomato+Condiments",
+    "image": null
+  },
+  {
+    "name": "Philadelphia Cream Cheese Spread Original Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Philadelphia+Cream+Cheese+Spread+Original+Dairy",
+    "image": null
+  },
+  {
+    "name": "Store brand Cheddar Cheese Medium Sliced,  Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Store+brand+Cheddar+Cheese+Medium+Sliced%2C+Dairy",
+    "image": null
+  },
+  {
+    "name": "Daisy Sour Cream  Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Daisy+Sour+Cream+Dairy",
+    "image": null
+  },
+  {
+    "name": "Dawn Dishwand Ultra Soap Dispensing Cleaning Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Dawn+Dishwand+Ultra+Soap+Dispensing+Cleaning+Supplies",
+    "image": null
+  },
+  {
+    "name": "Dawn Dishwashing Liquid Platinum Refreshing Rain Cleaning Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Dawn+Dishwashing+Liquid+Platinum+Refreshing+Rain+Cleaning+Supplies",
+    "image": null
+  },
+  {
+    "name": "Store brand Parmesan Cheese Grated,  Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Store+brand+Parmesan+Cheese+Grated%2C+Dairy",
+    "image": null
+  },
+  {
+    "name": "Diamond of California Pecans Finely Diced Baking Nuts",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Diamond+of+California+Pecans+Finely+Diced+Baking+Nuts",
+    "image": null
+  },
+  {
+    "name": "Domino Powdered Sugar Premium Cane Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Domino+Powdered+Sugar+Premium+Cane+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Filippo Berio Olive Oil Extra Light Cooking Oils",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Filippo+Berio+Olive+Oil+Extra+Light+Cooking+Oils",
+    "image": null
+  },
+  {
+    "name": "Stouffer's Mac N Cheese Bites  Frozen Foods",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Stouffer's+Mac+N+Cheese+Bites+Frozen+Foods",
+    "image": null
+  },
+  {
+    "name": "Frank's RedHot Sauce Original Condiments Sauces",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Frank's+RedHot+Sauce+Original+Condiments+Sauces",
+    "image": null
+  },
+  {
+    "name": "French's Mustard Classic Yellow Condiments",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=French's+Mustard+Classic+Yellow+Condiments",
+    "image": null
+  },
+  {
+    "name": "Frenches Fried Onions Crispy  Condiments",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Frenches+Fried+Onions+Crispy+Condiments",
+    "image": null
+  },
+  {
+    "name": "Glad Trash Bags 13 Gallon, forceflex, fresh clean Cleaning",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Glad+Trash+Bags+13+Gallon%2C+forceflex%2C+fresh+clean+Cleaning",
+    "image": null
+  },
+  {
+    "name": "Broccoli Frozen Frozen Foods",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Broccoli+Frozen+Frozen+Foods",
+    "image": null
+  },
+  {
+    "name": "Green Mountain Coffee K-Cup Pods Nantucket Blend, Medium Roast Coffee & Tea",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Green+Mountain+Coffee+K-Cup+Pods+Nantucket+Blend%2C+Medium+Roast+Coffee+%26+Tea",
+    "image": null
+  },
+  {
+    "name": "Grey Poupon Mustard Dijon Condiments",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Grey+Poupon+Mustard+Dijon+Condiments",
+    "image": null
+  },
+  {
+    "name": "Gulden's Mustard Spicy Brown Condiments",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Gulden's+Mustard+Spicy+Brown+Condiments",
+    "image": null
+  },
+  {
+    "name": "Hamburger Helper Pasta Meal Deluxe Beef Stroganoff Packaged Meals",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Hamburger+Helper+Pasta+Meal+Deluxe+Beef+Stroganoff+Packaged+Meals",
+    "image": null
+  },
+  {
+    "name": "Hamburger Helper Pasta Meal Potatoes Stroganoff Packaged Meals",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Hamburger+Helper+Pasta+Meal+Potatoes+Stroganoff+Packaged+Meals",
+    "image": null
+  },
+  {
+    "name": "Hass Avocados 4 ct Fresh Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Hass+Avocados+4+ct+Fresh+Produce",
+    "image": null
+  },
+  {
+    "name": "Ice Cream  Frozen Foods",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Ice+Cream+Frozen+Foods",
+    "image": null
+  },
+  {
+    "name": "Hellmann's Mayonnaise Real Condiments Spreads",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Hellmann's+Mayonnaise+Real+Condiments+Spreads",
+    "image": null
+  },
+  {
+    "name": "Hellmann's Mayonnaise Real Squeeze Bottle Condiments",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Hellmann's+Mayonnaise+Real+Squeeze+Bottle+Condiments",
+    "image": null
+  },
+  {
+    "name": "Hellmann's Mayonnaise Spicy Condiments",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Hellmann's+Mayonnaise+Spicy+Condiments",
+    "image": null
+  },
+  {
+    "name": "Hershey's Cocoa  Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Hershey's+Cocoa+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Hershey's Syrup Genuine Chocolate Flavor Condiments Syrups",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Hershey's+Syrup+Genuine+Chocolate+Flavor+Condiments+Syrups",
+    "image": null
+  },
+  {
+    "name": "Hormel Canned Chicken Breast  Canned Meats",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Hormel+Canned+Chicken+Breast+Canned+Meats",
+    "image": null
+  },
+  {
+    "name": "Del Monte Mixed Vegetables  Canned",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Del+Monte+Mixed+Vegetables+Canned",
+    "image": null
+  },
+  {
+    "name": "I Can't Believe It's Not Butter! Butter Spray Original Spreads",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=I+Can't+Believe+It's+Not+Butter!+Butter+Spray+Original+Spreads",
+    "image": null
+  },
+  {
+    "name": "I Can't Believe It's Not Butter! Butter Substitute  Spreads",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=I+Can't+Believe+It's+Not+Butter!+Butter+Substitute+Spreads",
+    "image": null
+  },
+  {
+    "name": "Idahoan Mashed Potatoes Loaded Baked Side Dishes",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Idahoan+Mashed+Potatoes+Loaded+Baked+Side+Dishes",
+    "image": null
+  },
+  {
+    "name": "Jif Peanut Butter Creamy Spreads",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Jif+Peanut+Butter+Creamy+Spreads",
+    "image": null
+  },
+  {
+    "name": "Ken's Steak House Blue Cheese Dressing Chunky Condiments Dressings",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Ken's+Steak+House+Blue+Cheese+Dressing+Chunky+Condiments+Dressings",
+    "image": null
+  },
+  {
+    "name": "Kerrygold Butter Pure Irish, Unsalted Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Kerrygold+Butter+Pure+Irish%2C+Unsalted+Dairy",
+    "image": null
+  },
+  {
+    "name": "Kikkoman Marinade & Sauce Teriyaki Condiments Sauces",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Kikkoman+Marinade+%26+Sauce+Teriyaki+Condiments+Sauces",
+    "image": null
+  },
+  {
+    "name": "Beef Steak Tips Meat",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Beef+Steak+Tips+Meat",
+    "image": null
+  },
+  {
+    "name": "Kozy Shack Rice Pudding Original Recipe, Gluten Free Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Kozy+Shack+Rice+Pudding+Original+Recipe%2C+Gluten+Free+Dairy",
+    "image": null
+  },
+  {
+    "name": "Lindy Italian Ice  Frozen Foods",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Lindy+Italian+Ice+Frozen+Foods",
+    "image": null
+  },
+  {
+    "name": "Krusteaz Muffin Mix Cranberry Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Krusteaz+Muffin+Mix+Cranberry+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Lea & Perrins Worcestershire Sauce The Original Condiments Sauces",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Lea+%26+Perrins+Worcestershire+Sauce+The+Original+Condiments+Sauces",
+    "image": null
+  },
+  {
+    "name": "Libbys Pumpkin 100 pure Canned",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Libbys+Pumpkin+100+pure+Canned",
+    "image": null
+  },
+  {
+    "name": "Store Brand Mushrooms Stems and Pieces  Canned",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Store+Brand+Mushrooms+Stems+and+Pieces+Canned",
+    "image": null
+  },
+  {
+    "name": "McCormick Cream of Tartar  Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=McCormick+Cream+of+Tartar+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Milk-Bone Flavor Snacks  Pet Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Milk-Bone+Flavor+Snacks+Pet+Supplies",
+    "image": null
+  },
+  {
+    "name": "Bread Sour Dough Bakery & Bread",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Bread+Sour+Dough+Bakery+%26+Bread",
+    "image": null
+  },
+  {
+    "name": "Monster Energy Drink  Beverages",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Monster+Energy+Drink+Beverages",
+    "image": null
+  },
+  {
+    "name": "Mott's Applesauce  Snacks Fruits",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Mott's+Applesauce+Snacks+Fruits",
+    "image": null
+  },
+  {
+    "name": "Mrs. Butterworth's Syrup Extra Buttery Condiments Syrups",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Mrs.+Butterworth's+Syrup+Extra+Buttery+Condiments+Syrups",
+    "image": null
+  },
+  {
+    "name": "Mt. Olive Pickles Bread & Butter Chips Condiments Pickles",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Mt.+Olive+Pickles+Bread+%26+Butter+Chips+Condiments+Pickles",
+    "image": null
+  },
+  {
+    "name": "Nature's Promise Garlic Minced Cooking Ingredients",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Nature's+Promise+Garlic+Minced+Cooking+Ingredients",
+    "image": null
+  },
+  {
+    "name": "Nestle Nesquik Chocolate Beverage Mixes",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Nestle+Nesquik+Chocolate+Beverage+Mixes",
+    "image": null
+  },
+  {
+    "name": "Nudges Grillers  Pet Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Nudges+Grillers+Pet+Supplies",
+    "image": null
+  },
+  {
+    "name": "Ocean Spray Cranberry Sauce Jellied Canned Fruits",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Ocean+Spray+Cranberry+Sauce+Jellied+Canned+Fruits",
+    "image": null
+  },
+  {
+    "name": "Pace Salsa Chunky Mild Condiments",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Pace+Salsa+Chunky+Mild+Condiments",
+    "image": null
+  },
+  {
+    "name": "Paper Plate Everyday 8.5",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Paper+Plate+Everyday+8.5",
+    "image": null
+  },
+  {
+    "name": "College Inn Beef Stock  Broth & Bouillon",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=College+Inn+Beef+Stock+Broth+%26+Bouillon",
+    "image": null
+  },
+  {
+    "name": "Perdue Chicken Breast Cutlets  Meat & Poultry",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Perdue+Chicken+Breast+Cutlets+Meat+%26+Poultry",
+    "image": null
+  },
+  {
+    "name": "Hormel Corned Beef Hash Mary Kitchen Canned Meats",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Hormel+Corned+Beef+Hash+Mary+Kitchen+Canned+Meats",
+    "image": null
+  },
+  {
+    "name": "Pepsi Soda Zero Beverages",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Pepsi+Soda+Zero+Beverages",
+    "image": null
+  },
+  {
+    "name": "Progresso Soup Traditional Chickarina Soup",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Progresso+Soup+Traditional+Chickarina+Soup",
+    "image": null
+  },
+  {
+    "name": "Progresso Soup Traditional Chicken & Wild Rice Soup",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Progresso+Soup+Traditional+Chicken+%26+Wild+Rice+Soup",
+    "image": null
+  },
+  {
+    "name": "Planters Peanuts Cocktail Snacks",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Planters+Peanuts+Cocktail+Snacks",
+    "image": null
+  },
+  {
+    "name": "Quaker Instant Oatmeal Strawberries n Cream Breakfast Cereals",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Quaker+Instant+Oatmeal+Strawberries+n+Cream+Breakfast+Cereals",
+    "image": null
+  },
+  {
+    "name": "Spectrum Sesame Oil Organic Toasted Cooking Oils",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Spectrum+Sesame+Oil+Organic+Toasted+Cooking+Oils",
+    "image": null
+  },
+  {
+    "name": "Spice Islands Almond Extract Pure Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Spice+Islands+Almond+Extract+Pure+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Store brand Apple Cider Vinegar  Vinegars",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Store+brand+Apple+Cider+Vinegar+Vinegars",
+    "image": null
+  },
+  {
+    "name": "Store brand Baking Powder Double Acting,  Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Store+brand+Baking+Powder+Double+Acting%2C+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Tuttorosso Tomatoes Diced, Canned Canned Goods",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Tuttorosso+Tomatoes+Diced%2C+Canned+Canned+Goods",
+    "image": null
+  },
+  {
+    "name": "College Inn Chicken Broth  Broth & Bouillon",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=College+Inn+Chicken+Broth+Broth+%26+Bouillon",
+    "image": null
+  },
+  {
+    "name": "Kikkoman Soy Sauce Less Sodium Condiments Sauces",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Kikkoman+Soy+Sauce+Less+Sodium+Condiments+Sauces",
+    "image": null
+  },
+  {
+    "name": "Store brand Parmesan Cheese Shredded Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Store+brand+Parmesan+Cheese+Shredded+Dairy",
+    "image": null
+  },
+  {
+    "name": "Store brand Ricotta Cheese Brand  Sargento Dairy",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Store+brand+Ricotta+Cheese+Brand+Sargento+Dairy",
+    "image": null
+  },
+  {
+    "name": "Store brand Spinach Washed Fresh Produce",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Store+brand+Spinach+Washed+Fresh+Produce",
+    "image": null
+  },
+  {
+    "name": "Store brand Vanilla Extract Pure Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Store+brand+Vanilla+Extract+Pure+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Store brand Vinegar White Vinegars",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Store+brand+Vinegar+White+Vinegars",
+    "image": null
+  },
+  {
+    "name": "Frozen Vegetables Peas and Corn Frozen Foods",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Frozen+Vegetables+Peas+and+Corn+Frozen+Foods",
+    "image": null
+  },
+  {
+    "name": "Sweet Baby Ray's Barbecue Sauce  Condiments Sauces",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Sweet+Baby+Ray's+Barbecue+Sauce+Condiments+Sauces",
+    "image": null
+  },
+  {
+    "name": "Sweet Baby Ray's Sauce Sweet Teriyaki Condiments Sauces",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Sweet+Baby+Ray's+Sauce+Sweet+Teriyaki+Condiments+Sauces",
+    "image": null
+  },
+  {
+    "name": "Taste of Inspirations Gnocchi Potato, Made in Italy Pasta",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Taste+of+Inspirations+Gnocchi+Potato%2C+Made+in+Italy+Pasta",
+    "image": null
+  },
+  {
+    "name": "Tostitos Salsa Chunky Mild Snacks Condiments",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Tostitos+Salsa+Chunky+Mild+Snacks+Condiments",
+    "image": null
+  },
+  {
+    "name": "Paper Bowl 10 oz",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Paper+Bowl+10+oz",
+    "image": null
+  },
+  {
+    "name": "Wilton Candy Melts Light Cocoa Baking Supplies",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Wilton+Candy+Melts+Light+Cocoa+Baking+Supplies",
+    "image": null
+  },
+  {
+    "name": "Wish-Bone Dressing House Italian Condiments Dressings",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Wish-Bone+Dressing+House+Italian+Condiments+Dressings",
+    "image": null
+  },
+  {
+    "name": "Yoo-hoo Chocolate Drink",
+    "store": "Amazon",
+    "price": null,
+    "convertedQty": null,
+    "pricePerUnit": null,
+    "link": "https://www.amazon.com/s?k=Yoo-hoo+Chocolate+Drink",
+    "image": null
   }
 ]

--- a/addItem.js
+++ b/addItem.js
@@ -14,7 +14,12 @@ const STORE_LINKS = {
   Walmart: name =>
     `https://www.walmart.com/search?q=${encodeURIComponent(
       name.replace(/ /g, '+')
-    )}&facet=fulfillment_method_in_store%3AIn-store%7C%7Cexclude_oos%3AShow+available+items+only`
+    )}&facet=fulfillment_method_in_store%3AIn-store%7C%7Cexclude_oos%3AShow+available+items+only`,
+  Amazon: name =>
+    `https://www.amazon.com/s?k=${name
+      .split(/\s+/)
+      .map(encodeURIComponent)
+      .join('+')}`
 };
 
 function loadArray(key, path) {
@@ -102,6 +107,15 @@ async function commit() {
       convertedQty: null,
       pricePerUnit: null,
       link: STORE_LINKS['Walmart'](name),
+      image: null
+    },
+    {
+      name,
+      store: 'Amazon',
+      price: null,
+      convertedQty: null,
+      pricePerUnit: null,
+      link: STORE_LINKS['Amazon'](name),
       image: null
     }
   );

--- a/contentScript.js
+++ b/contentScript.js
@@ -226,6 +226,69 @@ function scrapeWalmart() {
   return products;
 }
 
+function scrapeAmazon() {
+  const products = [];
+  const tiles = document.querySelectorAll(
+    'div[data-asin][data-component-type="s-search-result"]'
+  );
+  tiles.forEach(tile => {
+    const name = tile.querySelector('h2.a-size-base-plus span')?.innerText?.trim();
+    const image = tile.querySelector('img.s-image')?.src || '';
+    const priceText = tile
+      .querySelector('span.a-price span.a-offscreen')?.innerText?.trim();
+    const unitText = tile
+      .querySelector(
+        'span.a-size-base.a-color-secondary span.a-price.a-text-price span.a-offscreen'
+      )?.innerText?.trim();
+    const countText = tile
+      .querySelector('span.a-size-base.a-color-base.s-background-color-platinum')?.innerText?.trim();
+
+    let priceNumber = null;
+    if (priceText) {
+      const p = parseFloat(priceText.replace(/[^0-9.]/g, ''));
+      if (!isNaN(p)) priceNumber = p;
+    }
+
+    let pricePerUnit = null;
+    let unitType = null;
+    if (unitText) {
+      const m = unitText.match(/\$([\d.]+)\s*\/\s*(\w+)/);
+      if (m) {
+        pricePerUnit = parseFloat(m[1]);
+        unitType = m[2];
+      }
+    }
+
+    let sizeQty = null;
+    let sizeUnit = null;
+    if (countText) {
+      const m = countText.match(/([\d.]+)\s*(\w+)/);
+      if (m) {
+        sizeQty = parseFloat(m[1]);
+        sizeUnit = m[2];
+      }
+    }
+
+    if (name && priceText) {
+      products.push({
+        name,
+        price: priceText,
+        priceNumber,
+        size: countText || '',
+        sizeQty,
+        sizeUnit,
+        unit: unitText || '',
+        unitQty: null,
+        unitType,
+        convertedQty: null,
+        pricePerUnit,
+        image
+      });
+    }
+  });
+  return products;
+}
+
 function runScrape() {
   chrome.storage.local.get('currentItemInfo', info => {
     const { item = '', store = 'Stop & Shop' } = info.currentItemInfo || {};
@@ -234,6 +297,8 @@ function runScrape() {
       data = scrapeStopAndShop();
     } else if (store === 'Walmart') {
       data = scrapeWalmart();
+    } else if (store === 'Amazon') {
+      data = scrapeAmazon();
     }
     chrome.runtime.sendMessage({ type: 'scrapedData', item, store, products: data });
   });

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
   ],
   "host_permissions": [
     "https://stopandshop.com/*",
-    "https://www.walmart.com/*"
+    "https://www.walmart.com/*",
+    "https://www.amazon.com/*"
   ],
   "action": {
     "default_popup": "popup.html"
@@ -22,7 +23,8 @@
     {
       "matches": [
         "https://stopandshop.com/*",
-        "https://www.walmart.com/*"
+        "https://www.walmart.com/*",
+        "https://www.amazon.com/*"
       ],
       "js": [
         "contentScript.js"

--- a/scrapers/amazon.js
+++ b/scrapers/amazon.js
@@ -1,0 +1,55 @@
+export function scrapeAmazon() {
+  const products = [];
+  const tiles = document.querySelectorAll('div[data-asin][data-component-type="s-search-result"]');
+  tiles.forEach(tile => {
+    const name = tile.querySelector('h2.a-size-base-plus span')?.innerText?.trim();
+    const image = tile.querySelector('img.s-image')?.src || '';
+    const priceText = tile.querySelector('span.a-price span.a-offscreen')?.innerText?.trim();
+    const unitText = tile.querySelector('span.a-size-base.a-color-secondary span.a-price.a-text-price span.a-offscreen')?.innerText?.trim();
+    const countText = tile.querySelector('span.a-size-base.a-color-base.s-background-color-platinum')?.innerText?.trim();
+
+    let priceNumber = null;
+    if (priceText) {
+      const p = parseFloat(priceText.replace(/[^0-9.]/g, ''));
+      if (!isNaN(p)) priceNumber = p;
+    }
+
+    let pricePerUnit = null;
+    let unitType = null;
+    if (unitText) {
+      const m = unitText.match(/\$([\d.]+)\s*\/\s*(\w+)/);
+      if (m) {
+        pricePerUnit = parseFloat(m[1]);
+        unitType = m[2];
+      }
+    }
+
+    let sizeQty = null;
+    let sizeUnit = null;
+    if (countText) {
+      const m = countText.match(/([\d.]+)\s*(\w+)/);
+      if (m) {
+        sizeQty = parseFloat(m[1]);
+        sizeUnit = m[2];
+      }
+    }
+
+    if (name && priceText) {
+      products.push({
+        name,
+        price: priceText,
+        priceNumber,
+        size: countText || '',
+        sizeQty,
+        sizeUnit,
+        unit: unitText || '',
+        unitQty: null,
+        unitType,
+        convertedQty: null,
+        pricePerUnit,
+        image
+      });
+    }
+  });
+  return products;
+}


### PR DESCRIPTION
## Summary
- add Amazon search URLs for items and dataset
- support Amazon results in the extension content script and manifest
- include Amazon when adding new items
- provide scraper for Amazon

## Testing
- `node -e "console.log('node version', process.version)"`

------
https://chatgpt.com/codex/tasks/task_e_685014f9cad08329ab50bdc12a0722de