### PR TITLE
Fix UOM conversion for Shaw's scraper

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -290,6 +290,40 @@ function scrapeAmazon() {
 }
 
 function scrapeShaws() {
+  const UNIT_FACTORS = {
+    oz: 1,
+    lb: 16,
+    g: 0.035274,
+    kg: 35.274,
+    ml: 0.033814,
+    l: 33.814,
+    gal: 128,
+    qt: 32,
+    pt: 16,
+    cup: 8,
+    tbsp: 0.5,
+    tsp: 0.1667,
+    ea: 1,
+    ct: 1,
+    pkg: 1,
+    box: 1,
+    can: 1,
+    bag: 1,
+    bottle: 1,
+    stick: 1,
+    roll: 1,
+    bar: 1,
+    pouch: 1,
+    jar: 1,
+    packet: 1,
+    sleeve: 1,
+    slice: 1,
+    piece: 1,
+    tube: 1,
+    tray: 1,
+    unit: 1
+  };
+
   const products = [];
   const tiles = document.querySelectorAll('product-item-al-v2');
   tiles.forEach(tile => {
@@ -316,6 +350,18 @@ function scrapeShaws() {
       }
     }
 
+    let convertedQty = null;
+    let pricePerUnit = null;
+    if (sizeQty != null && sizeUnit) {
+      const factor = UNIT_FACTORS[sizeUnit.toLowerCase()];
+      if (factor) {
+        convertedQty = sizeQty * factor;
+        if (priceNumber != null) {
+          pricePerUnit = priceNumber / convertedQty;
+        }
+      }
+    }
+
     if (name && priceText) {
       products.push({
         name,
@@ -327,8 +373,8 @@ function scrapeShaws() {
         unit: '',
         unitQty: null,
         unitType: null,
-        convertedQty: null,
-        pricePerUnit: null,
+        convertedQty,
+        pricePerUnit,
         image
       });
     }

--- a/scrapers/shaws.js
+++ b/scrapers/shaws.js
@@ -1,4 +1,38 @@
 export function scrapeShaws() {
+  const UNIT_FACTORS = {
+    oz: 1,
+    lb: 16,
+    g: 0.035274,
+    kg: 35.274,
+    ml: 0.033814,
+    l: 33.814,
+    gal: 128,
+    qt: 32,
+    pt: 16,
+    cup: 8,
+    tbsp: 0.5,
+    tsp: 0.1667,
+    ea: 1,
+    ct: 1,
+    pkg: 1,
+    box: 1,
+    can: 1,
+    bag: 1,
+    bottle: 1,
+    stick: 1,
+    roll: 1,
+    bar: 1,
+    pouch: 1,
+    jar: 1,
+    packet: 1,
+    sleeve: 1,
+    slice: 1,
+    piece: 1,
+    tube: 1,
+    tray: 1,
+    unit: 1
+  };
+
   const products = [];
   const tiles = document.querySelectorAll('product-item-al-v2');
   tiles.forEach(tile => {
@@ -25,6 +59,18 @@ export function scrapeShaws() {
       }
     }
 
+    let convertedQty = null;
+    let pricePerUnit = null;
+    if (sizeQty != null && sizeUnit) {
+      const factor = UNIT_FACTORS[sizeUnit.toLowerCase()];
+      if (factor) {
+        convertedQty = sizeQty * factor;
+        if (priceNumber != null) {
+          pricePerUnit = priceNumber / convertedQty;
+        }
+      }
+    }
+
     if (name && priceText) {
       products.push({
         name,
@@ -36,8 +82,8 @@ export function scrapeShaws() {
         unit: '',
         unitQty: null,
         unitType: null,
-        convertedQty: null,
-        pricePerUnit: null,
+        convertedQty,
+        pricePerUnit,
         image
       });
     }


### PR DESCRIPTION
## Summary
- add UOM conversion logic to `scrapers/shaws.js`
- include the same conversion logic in `contentScript.js`

## Testing
- `node -e "import('./scrapers/shaws.js').then(m=>console.log('loaded', typeof m.scrapeShaws))" --experimental-modules`

------
https://chatgpt.com/codex/tasks/task_e_68501d540bf8832990e344224708db23