### PR TITLE
Fix Amazon multipack unit price parsing

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -268,7 +268,7 @@ function scrapeAmazon() {
     let unit = null;
     for (const field of fields) {
       if (!field) continue;
-      const m = field.match(/([\d.]+)\s*(oz|ounce|fluid ounce|fl oz|g|gram|kg|ml|l)/i);
+      const m = field.match(/([\d.]+)[\s-]*(oz|ounce|fluid ounce|fl oz|g|gram|kg|ml|l)/i);
       if (m) {
         unitSize = parseFloat(m[1]);
         unit = m[2].toLowerCase();
@@ -340,8 +340,14 @@ function scrapeAmazon() {
       convertedQty = sizeQty * UNIT_FACTORS[sizeUnit];
       if (priceNumber != null && totalQty != null) {
         const totalConverted = totalQty * UNIT_FACTORS[sizeUnit];
-        pricePerUnit = priceNumber / totalConverted;
-        unitType = 'oz';
+        if (
+          pricePerUnit == null ||
+          /count/i.test(unitText) ||
+          (unitType && /count/i.test(unitType))
+        ) {
+          pricePerUnit = priceNumber / totalConverted;
+          unitType = 'oz';
+        }
       }
     }
 

--- a/scrapers/amazon.js
+++ b/scrapers/amazon.js
@@ -40,7 +40,7 @@ export function scrapeAmazon() {
     let unit = null;
     for (const field of fields) {
       if (!field) continue;
-      const m = field.match(/([\d.]+)\s*(oz|ounce|fluid ounce|fl oz|g|gram|kg|ml|l)/i);
+      const m = field.match(/([\d.]+)[\s-]*(oz|ounce|fluid ounce|fl oz|g|gram|kg|ml|l)/i);
       if (m) {
         unitSize = parseFloat(m[1]);
         unit = m[2].toLowerCase();
@@ -111,8 +111,14 @@ export function scrapeAmazon() {
       convertedQty = sizeQty * UNIT_FACTORS[sizeUnit];
       if (priceNumber != null && totalQty != null) {
         const totalConverted = totalQty * UNIT_FACTORS[sizeUnit];
-        pricePerUnit = priceNumber / totalConverted;
-        unitType = 'oz';
+        if (
+          pricePerUnit == null ||
+          /count/i.test(unitText) ||
+          (unitType && /count/i.test(unitType))
+        ) {
+          pricePerUnit = priceNumber / totalConverted;
+          unitType = 'oz';
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- improve regex parsing for Amazon unit info to allow hyphenated sizes
- override $/count unit pricing when pack and weight can be parsed

## Testing
- `node -e "require('./scrapers/amazon.js');"`
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68502f146fcc8329af84262b04ddafa1