### PR TITLE
Fix Walmart price per oz calculation

### DIFF
--- a/scrapers/walmart.js
+++ b/scrapers/walmart.js
@@ -52,9 +52,6 @@ export function scrapeWalmart() {
     if (sizeMatch) {
       sizeQty = parseFloat(sizeMatch[1]);
       sizeUnit = sizeMatch[2].replace(/\s+/g, '');
-      if (packCount > 1) {
-        sizeQty = sizeQty / packCount;
-      }
       const factor = UNIT_FACTORS[sizeUnit.toLowerCase()];
       if (factor) {
         convertedQty = sizeQty * factor;
@@ -62,7 +59,8 @@ export function scrapeWalmart() {
         if (price) {
           const p = parseFloat(price.replace(/[^0-9.]/g, ''));
           if (!isNaN(p)) {
-            pricePerUnit = p / (convertedQty * packCount);
+            const totalConverted = convertedQty * packCount;
+            pricePerUnit = p / totalConverted;
           }
         }
       }


### PR DESCRIPTION
## Summary
- fix Walmart scraper calculation of price per ounce when packs are listed

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685034cbf66083298800e8faba12b0cc