### PR TITLE
Fix Walmart price per unit calculation

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -174,9 +174,11 @@ function scrapeWalmart() {
     if (sizeMatch) {
       sizeQty = parseFloat(sizeMatch[1]);
       sizeUnit = sizeMatch[2].replace(/\s+/g, '');
-      if (packCount > 1) {
-        sizeQty = sizeQty / packCount;
-      }
+      // Removed adjustment that divided size by packCount so that the
+      // full item weight is used when computing price per unit.
+      // if (packCount > 1) {
+      //   sizeQty = sizeQty / packCount;
+      // }
       const factor = UNIT_FACTORS[sizeUnit.toLowerCase()];
       if (factor) {
         convertedQty = sizeQty * factor;


### PR DESCRIPTION
## Summary
- remove size division by pack count to keep original weight
- compute price-per-unit with original weight times pack count

## Testing
- `node test_snippet.js`

------
https://chatgpt.com/codex/tasks/task_e_6850399de4988329938e005c0449b7b1