### PR TITLE
Add Hannaford scraper

### DIFF
--- a/Required for grocery app/store_links_base.csv
+++ b/Required for grocery app/store_links_base.csv
@@ -4,3 +4,4 @@ Walmart,https://www.walmart.com/search?q=%7C%7Cexclude_oos%3AShow+available+item
 Amazon,https://www.amazon.com/s?k=
 Shaws,https://www.shaws.com/shop/search-results.html?q=
 Roche Bros,https://shopping.rochebros.com/search?search_term=
+Hannaford,https://www.hannaford.com/search/product?keyword=

--- a/addItem.js
+++ b/addItem.js
@@ -23,7 +23,9 @@ const STORE_LINKS = {
   Shaws: name =>
     `https://www.shaws.com/shop/search-results.html?q=${name.replace(/ /g, '%20')}`,
   'Roche Bros': name =>
-    `https://shopping.rochebros.com/search?search_term=${name.replace(/ /g, '%20')}`
+    `https://shopping.rochebros.com/search?search_term=${name.replace(/ /g, '%20')}`,
+  Hannaford: name =>
+    `https://www.hannaford.com/search/product?form_state=searchForm&keyword=${name.replace(/ /g, '+')}&ieDummyTextField=&productTypeId=P`
 };
 
 function loadArray(key, path) {
@@ -138,6 +140,15 @@ async function commit() {
       convertedQty: null,
       pricePerUnit: null,
       link: STORE_LINKS['Roche Bros'](name),
+      image: null
+    },
+    {
+      name,
+      store: 'Hannaford',
+      price: null,
+      convertedQty: null,
+      pricePerUnit: null,
+      link: STORE_LINKS['Hannaford'](name),
       image: null
     }
   );

--- a/contentScript.js
+++ b/contentScript.js
@@ -569,6 +569,113 @@ function scrapeRocheBros() {
   return products;
 }
 
+function scrapeHannaford() {
+  const UNIT_FACTORS = {
+    oz: 1,
+    lb: 16,
+    g: 0.035274,
+    kg: 35.274,
+    ml: 0.033814,
+    l: 33.814,
+    gal: 128,
+    qt: 32,
+    pt: 16,
+    cup: 8,
+    tbsp: 0.5,
+    tsp: 0.1667,
+    ea: 1,
+    ct: 1,
+    pkg: 1,
+    box: 1,
+    can: 1,
+    bag: 1,
+    bottle: 1,
+    stick: 1,
+    roll: 1,
+    bar: 1,
+    pouch: 1,
+    jar: 1,
+    packet: 1,
+    sleeve: 1,
+    slice: 1,
+    piece: 1,
+    tube: 1,
+    tray: 1,
+    unit: 1
+  };
+
+  const products = [];
+  const tiles = document.querySelectorAll('div.catalog-product');
+  tiles.forEach(tile => {
+    const name = tile.querySelector('.productName .real-product-name')?.innerText?.trim();
+    const priceText = tile.querySelector('.priceCell .item-unit-price')?.innerText?.trim();
+    const priceHidden = tile.querySelector('.priceCell .item-price')?.value;
+    const sizeText = tile.querySelector('.overline.text-truncate')?.innerText?.trim();
+    const unitText = tile.querySelector('.unitPriceDisplay')?.innerText?.trim();
+    const image = tile.querySelector('img')?.src || '';
+
+    let priceNumber = null;
+    if (priceHidden) {
+      const p = parseFloat(priceHidden);
+      if (!isNaN(p)) priceNumber = p;
+    } else if (priceText) {
+      const m = priceText.match(/\$?([0-9.]+)/);
+      if (m) priceNumber = parseFloat(m[1]);
+    }
+
+    let unitQty = null;
+    let unitType = null;
+    if (unitText) {
+      const clean = unitText.replace(/[^0-9./a-zA-Z]/g, '');
+      const match = clean.match(/([\d.]+)\/([a-zA-Z]+)/);
+      if (match) {
+        unitQty = parseFloat(match[1]);
+        unitType = match[2];
+      }
+    }
+
+    let sizeQty = null;
+    let sizeUnit = null;
+    if (sizeText) {
+      const m = sizeText.match(/([\d.]+)\s*([a-zA-Z]+)/);
+      if (m) {
+        sizeQty = parseFloat(m[1]);
+        sizeUnit = m[2];
+      }
+    }
+
+    let convertedQty = null;
+    let pricePerUnit = null;
+    if (sizeQty != null && sizeUnit) {
+      const factor = UNIT_FACTORS[sizeUnit.toLowerCase()];
+      if (factor) {
+        convertedQty = sizeQty * factor;
+        if (priceNumber != null) {
+          pricePerUnit = priceNumber / convertedQty;
+        }
+      }
+    }
+
+    if (name && (priceText || priceNumber != null)) {
+      products.push({
+        name,
+        price: priceText || (priceNumber != null ? `$${priceNumber.toFixed(2)}` : ''),
+        priceNumber,
+        size: sizeText || '',
+        sizeQty,
+        sizeUnit,
+        unit: unitText || '',
+        unitQty,
+        unitType,
+        convertedQty,
+        pricePerUnit,
+        image
+      });
+    }
+  });
+  return products;
+}
+
 function runScrape() {
   chrome.storage.local.get('currentItemInfo', info => {
     const { item = '', store = 'Stop & Shop' } = info.currentItemInfo || {};
@@ -583,6 +690,8 @@ function runScrape() {
       data = scrapeShaws();
     } else if (store === 'Roche Bros') {
       data = scrapeRocheBros();
+    } else if (store === 'Hannaford') {
+      data = scrapeHannaford();
     }
     chrome.runtime.sendMessage({ type: 'scrapedData', item, store, products: data });
   });

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
     "https://www.walmart.com/*",
     "https://www.amazon.com/*",
     "https://www.shaws.com/*",
-    "https://shopping.rochebros.com/*"
+    "https://shopping.rochebros.com/*",
+    "https://www.hannaford.com/*"
   ],
   "action": {
     "default_popup": "popup.html"
@@ -28,7 +29,8 @@
         "https://www.walmart.com/*",
         "https://www.amazon.com/*",
         "https://www.shaws.com/*",
-        "https://shopping.rochebros.com/*"
+        "https://shopping.rochebros.com/*",
+        "https://www.hannaford.com/*"
       ],
       "js": [
         "contentScript.js"

--- a/scrapers/hannaford.js
+++ b/scrapers/hannaford.js
@@ -1,0 +1,106 @@
+export function scrapeHannaford() {
+  const UNIT_FACTORS = {
+    oz: 1,
+    lb: 16,
+    g: 0.035274,
+    kg: 35.274,
+    ml: 0.033814,
+    l: 33.814,
+    gal: 128,
+    qt: 32,
+    pt: 16,
+    cup: 8,
+    tbsp: 0.5,
+    tsp: 0.1667,
+    ea: 1,
+    ct: 1,
+    pkg: 1,
+    box: 1,
+    can: 1,
+    bag: 1,
+    bottle: 1,
+    stick: 1,
+    roll: 1,
+    bar: 1,
+    pouch: 1,
+    jar: 1,
+    packet: 1,
+    sleeve: 1,
+    slice: 1,
+    piece: 1,
+    tube: 1,
+    tray: 1,
+    unit: 1
+  };
+
+  const products = [];
+  const tiles = document.querySelectorAll('div.catalog-product');
+  tiles.forEach(tile => {
+    const name = tile.querySelector('.productName .real-product-name')?.innerText?.trim();
+    const priceText = tile.querySelector('.priceCell .item-unit-price')?.innerText?.trim();
+    const priceHidden = tile.querySelector('.priceCell .item-price')?.value;
+    const sizeText = tile.querySelector('.overline.text-truncate')?.innerText?.trim();
+    const unitText = tile.querySelector('.unitPriceDisplay')?.innerText?.trim();
+    const image = tile.querySelector('img')?.src || '';
+
+    let priceNumber = null;
+    if (priceHidden) {
+      const p = parseFloat(priceHidden);
+      if (!isNaN(p)) priceNumber = p;
+    } else if (priceText) {
+      const m = priceText.match(/\$?([0-9.]+)/);
+      if (m) priceNumber = parseFloat(m[1]);
+    }
+
+    let unitQty = null;
+    let unitType = null;
+    if (unitText) {
+      const clean = unitText.replace(/[^0-9./a-zA-Z]/g, '');
+      const match = clean.match(/([\d.]+)\/([a-zA-Z]+)/);
+      if (match) {
+        unitQty = parseFloat(match[1]);
+        unitType = match[2];
+      }
+    }
+
+    let sizeQty = null;
+    let sizeUnit = null;
+    if (sizeText) {
+      const m = sizeText.match(/([\d.]+)\s*([a-zA-Z]+)/);
+      if (m) {
+        sizeQty = parseFloat(m[1]);
+        sizeUnit = m[2];
+      }
+    }
+
+    let convertedQty = null;
+    let pricePerUnit = null;
+    if (sizeQty != null && sizeUnit) {
+      const factor = UNIT_FACTORS[sizeUnit.toLowerCase()];
+      if (factor) {
+        convertedQty = sizeQty * factor;
+        if (priceNumber != null) {
+          pricePerUnit = priceNumber / convertedQty;
+        }
+      }
+    }
+
+    if (name && (priceText || priceNumber != null)) {
+      products.push({
+        name,
+        price: priceText || (priceNumber != null ? `$${priceNumber.toFixed(2)}` : ''),
+        priceNumber,
+        size: sizeText || '',
+        sizeQty,
+        sizeUnit,
+        unit: unitText || '',
+        unitQty,
+        unitType,
+        convertedQty,
+        pricePerUnit,
+        image
+      });
+    }
+  });
+  return products;
+}


### PR DESCRIPTION
## Summary
- add Hannaford scraper logic
- support Hannaford in extension content script
- update store links and selection defaults
- update Chrome extension manifest for Hannaford domain

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685042c37e60832999459846aae5a501