### PR TITLE
Add product links for Hannaford and display view button

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -108,7 +108,8 @@ function scrapeStopAndShop() {
         unitType,
         convertedQty,
         pricePerUnit,
-        image
+        image,
+        link
       });
     }
   });
@@ -221,7 +222,8 @@ function scrapeWalmart() {
         unitType,
         convertedQty,
         pricePerUnit,
-        image
+        image,
+        link
       });
     }
   });
@@ -607,6 +609,10 @@ function scrapeHannaford() {
   const products = [];
   const tiles = document.querySelectorAll('div.catalog-product');
   tiles.forEach(tile => {
+    const linkRel = tile.getAttribute('href') || tile.getAttribute('data-url');
+    const link = linkRel
+      ? new URL(linkRel, 'https://www.hannaford.com').href
+      : '';
     const name = tile.querySelector('.productName .real-product-name')?.innerText?.trim();
     const priceText = tile.querySelector('.priceCell .item-unit-price')?.innerText?.trim();
     const priceHidden = tile.querySelector('.priceCell .item-price')?.value;
@@ -669,7 +675,8 @@ function scrapeHannaford() {
         unitType,
         convertedQty,
         pricePerUnit,
-        image
+        image,
+        link
       });
     }
   });

--- a/scrapers/hannaford.js
+++ b/scrapers/hannaford.js
@@ -36,6 +36,10 @@ export function scrapeHannaford() {
   const products = [];
   const tiles = document.querySelectorAll('div.catalog-product');
   tiles.forEach(tile => {
+    const linkRel = tile.getAttribute('href') || tile.getAttribute('data-url');
+    const link = linkRel
+      ? new URL(linkRel, 'https://www.hannaford.com').href
+      : '';
     const name = tile.querySelector('.productName .real-product-name')?.innerText?.trim();
     const priceText = tile.querySelector('.priceCell .item-unit-price')?.innerText?.trim();
     const priceHidden = tile.querySelector('.priceCell .item-price')?.value;
@@ -98,7 +102,8 @@ export function scrapeHannaford() {
         unitType,
         convertedQty,
         pricePerUnit,
-        image
+        image,
+        link
       });
     }
   });

--- a/shoppingList.js
+++ b/shoppingList.js
@@ -42,6 +42,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         const amt = it.amount != null ? `${it.amount.toFixed(2)} ${it.unit}` : '';
         span.textContent = `${it.item} - ${it.product?.name || ''} - ${pStr} - ${qStr} - ${uStr} - ${amt}`;
         li.appendChild(span);
+        if (it.product && it.product.link) {
+          const btn = document.createElement('button');
+          btn.textContent = 'View';
+          btn.addEventListener('click', () => {
+            chrome.windows.create({ url: it.product.link, type: 'popup', width: 800, height: 800 });
+          });
+          li.appendChild(btn);
+        }
         ul.appendChild(li);
       });
       container.appendChild(ul);


### PR DESCRIPTION
## Summary
- scrape product page links from Hannaford tiles
- include these links when scraping in content script
- show a `View` button in the shopping list that opens the product page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685049fb7b9c83299fd2665f314d9253