### PR TITLE
Fix sorting of Amazon results by unit price

### DIFF
--- a/scrapers/amazon.js
+++ b/scrapers/amazon.js
@@ -141,5 +141,12 @@ export function scrapeAmazon() {
       });
     }
   });
+
+  products.sort((a, b) => {
+    const aPrice = a.pricePerUnit ?? Infinity;
+    const bPrice = b.pricePerUnit ?? Infinity;
+    return aPrice - bPrice;
+  });
+
   return products;
 }


### PR DESCRIPTION
## Summary
- sort products inside Amazon scraper by unit price before returning

## Testing
- `node -e "const fs=require('fs'); console.log('file size', fs.readFileSync('scrapers/amazon.js','utf8').length);"`

------
https://chatgpt.com/codex/tasks/task_e_68505f82cb3c8329a3afa4ccb911236d