### PR TITLE
Enable Shaws links and Roche Bros cart automation

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -418,7 +418,10 @@ function scrapeShaws() {
   const products = [];
   const tiles = document.querySelectorAll('product-item-al-v2');
   tiles.forEach(tile => {
-    const link = tile.querySelector('[data-qa="prd-itm-pttl"] a')?.href || '';
+    const linkRel = tile
+      .querySelector('[data-qa="prd-itm-pttl"] a')
+      ?.getAttribute('href');
+    const link = linkRel ? new URL(linkRel, 'https://www.shaws.com').href : '';
     const name =
       tile.querySelector('[data-qa="prd-itm-pttl"] a')?.innerText?.trim() ||
       tile.querySelector('[data-qa="prd-itm-pttl"]')?.innerText?.trim();
@@ -516,6 +519,9 @@ function scrapeRocheBros() {
     const name = tile.querySelector('.cell-title-text')?.innerText?.trim();
     const image = tile.querySelector('.cell-image')?.getAttribute('data-src') || '';
     const link = tile.querySelector('a[href]')?.href || '';
+    const addToCartId = tile
+      .querySelector('button[data-test-id^="add-to-cart-button"]')
+      ?.getAttribute('data-test-id') || '';
     const priceText = tile.querySelector('span[data-test="amount"] span')?.innerText?.trim();
     const perUnitText = tile.querySelector('span[data-test="per-unit-price"]')?.innerText?.trim();
     const sizeText = tile.querySelector('.cell-product-size')?.innerText?.trim();
@@ -573,7 +579,8 @@ function scrapeRocheBros() {
         convertedQty,
         pricePerUnit,
         image,
-        link
+        link,
+        addToCartId
       });
     }
   });
@@ -720,5 +727,8 @@ setTimeout(runScrape, 1000);
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'triggerScrape') {
     runScrape();
+  } else if (message.type === 'simulateClick' && message.selector) {
+    const el = document.querySelector(message.selector);
+    if (el) el.click();
   }
 });

--- a/scrapers/rochebros.js
+++ b/scrapers/rochebros.js
@@ -38,6 +38,9 @@ export function scrapeRocheBros() {
   tiles.forEach(tile => {
     const name = tile.querySelector('.cell-title-text')?.innerText?.trim();
     const link = tile.querySelector('a[href]')?.href || '';
+    const addToCartId = tile
+      .querySelector('button[data-test-id^="add-to-cart-button"]')
+      ?.getAttribute('data-test-id') || '';
     const priceText = tile.querySelector('[data-test="amount"] span')?.innerText?.trim();
     const sizeText = tile.querySelector('.cell-product-size')?.innerText?.trim();
     const unitText = tile.querySelector('[data-test="per-unit-price"]')?.innerText?.trim();
@@ -106,7 +109,8 @@ export function scrapeRocheBros() {
         convertedQty,
         pricePerUnit,
         image,
-        link
+        link,
+        addToCartId
       });
     }
   });

--- a/scrapers/shaws.js
+++ b/scrapers/shaws.js
@@ -39,7 +39,10 @@ export function scrapeShaws() {
     const name =
       tile.querySelector('[data-qa="prd-itm-pttl"] a')?.innerText?.trim() ||
       tile.querySelector('[data-qa="prd-itm-pttl"]')?.innerText?.trim();
-    const link = tile.querySelector('[data-qa="prd-itm-pttl"] a')?.href || '';
+    const linkRel = tile
+      .querySelector('[data-qa="prd-itm-pttl"] a')
+      ?.getAttribute('href');
+    const link = linkRel ? new URL(linkRel, 'https://www.shaws.com').href : '';
     const priceText = tile.querySelector('[data-qa="prd-itm-prc"]')?.innerText?.trim();
     const sizeText = tile.querySelector('[data-qa="prd-itm-sqty"]')?.innerText?.trim();
     const image = tile.querySelector('img[data-qa="prd-itm-img"]')?.src || '';

--- a/shoppingList.js
+++ b/shoppingList.js
@@ -9,6 +9,11 @@ function loadCommitItems() {
 const PLACEHOLDER_IMG =
   "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='50' height='50'><rect width='100%' height='100%' fill='%23ccc'/></svg>";
 
+const STORE_LINKS = {
+  'Roche Bros': name =>
+    `https://shopping.rochebros.com/search?search_term=${name.replace(/ /g, '%20')}`
+};
+
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('list');
   const items = await loadCommitItems();
@@ -42,7 +47,30 @@ document.addEventListener('DOMContentLoaded', async () => {
         const amt = it.amount != null ? `${it.amount.toFixed(2)} ${it.unit}` : '';
         span.textContent = `${it.item} - ${it.product?.name || ''} - ${pStr} - ${qStr} - ${uStr} - ${amt}`;
         li.appendChild(span);
-        if (it.product && it.product.link) {
+        if (it.store === 'Roche Bros' && it.product?.addToCartId) {
+          const btn = document.createElement('button');
+          btn.textContent = 'Add to Cart';
+          btn.addEventListener('click', () => {
+            chrome.runtime.sendMessage(
+              {
+                type: 'openStoreTab',
+                url: STORE_LINKS['Roche Bros'](it.item),
+                item: it.item,
+                store: 'Roche Bros'
+              },
+              response => {
+                const tabId = response.tabId;
+                setTimeout(() => {
+                  chrome.tabs.sendMessage(tabId, {
+                    type: 'simulateClick',
+                    selector: `[data-test-id="${it.product.addToCartId}"]`
+                  });
+                }, 3000);
+              }
+            );
+          });
+          li.appendChild(btn);
+        } else if (it.product && it.product.link) {
           const btn = document.createElement('button');
           btn.textContent = 'View';
           btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- convert relative Shaws product links to full URLs
- capture Roche Bros add-to-cart identifiers
- support simulating cart clicks in content script
- provide "Add to Cart" button in shopping list for Roche Bros items

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850650224688329ad1cc6594d295ca2