### PR TITLE
Fix unit price parsing for various stores

### DIFF
--- a/scrapers/hannaford.js
+++ b/scrapers/hannaford.js
@@ -1,6 +1,7 @@
 export function scrapeHannaford() {
   const UNIT_FACTORS = {
     oz: 1,
+    floz: 1,
     lb: 16,
     g: 0.035274,
     kg: 35.274,
@@ -60,20 +61,22 @@ export function scrapeHannaford() {
     let unitType = null;
     if (unitText) {
       const clean = unitText.replace(/[^0-9./a-zA-Z]/g, '');
-      const match = clean.match(/([\d.]+)\/([a-zA-Z]+)/);
+      const match = clean.match(/([\d.]+)\/(fl\s*oz|oz|lb|g|kg|ml|l|gal|qt|pt|cup|tbsp|tsp|ea|ct|pkg|box|can|bag|bottle|stick|roll|bar|pouch|jar|packet|sleeve|slice|piece|tube|tray|unit)/i);
       if (match) {
         unitQty = parseFloat(match[1]);
-        unitType = match[2];
+        unitType = match[2].toLowerCase().replace(/\s+/g, '');
+        if (unitType === 'floz') unitType = 'oz';
       }
     }
 
     let sizeQty = null;
     let sizeUnit = null;
     if (sizeText) {
-      const m = sizeText.match(/([\d.]+)\s*([a-zA-Z]+)/);
+      const m = sizeText.match(/([\d.]+)\s*(fl\s*oz|oz|lb|g|kg|ml|l|gal|qt|pt|cup|tbsp|tsp|ea|ct|pkg|box|can|bag|bottle|stick|roll|bar|pouch|jar|packet|sleeve|slice|piece|tube|tray|unit)/i);
       if (m) {
         sizeQty = parseFloat(m[1]);
-        sizeUnit = m[2];
+        sizeUnit = m[2].toLowerCase().replace(/\s+/g, '');
+        if (sizeUnit === 'floz') sizeUnit = 'oz';
       }
     }
 

--- a/scrapers/rochebros.js
+++ b/scrapers/rochebros.js
@@ -1,6 +1,7 @@
 export function scrapeRocheBros() {
   const UNIT_FACTORS = {
     oz: 1,
+    floz: 1,
     lb: 16,
     g: 0.035274,
     kg: 35.274,
@@ -60,10 +61,11 @@ export function scrapeRocheBros() {
     let sizeQty = null;
     let sizeUnit = null;
     if (sizeText) {
-      const m = sizeText.match(/([\d.]+)\s*([a-zA-Z]+)/);
+      const m = sizeText.match(/([\d.]+)\s*(fl\s*oz|oz|lb|g|kg|ml|l|gal|qt|pt|cup|tbsp|tsp|ea|ct|pkg|box|can|bag|bottle|stick|roll|bar|pouch|jar|packet|sleeve|slice|piece|tube|tray|unit)/i);
       if (m) {
         sizeQty = parseFloat(m[1]);
-        sizeUnit = m[2];
+        sizeUnit = m[2].toLowerCase().replace(/\s+/g, '');
+        if (sizeUnit === 'floz') sizeUnit = 'oz';
       }
     }
 
@@ -71,11 +73,11 @@ export function scrapeRocheBros() {
     let unitType = null;
     let pricePerUnit = null;
     if (unitText) {
-      const m = unitText.match(/\$([\d.]+)\s*\/\s*(\w+)/);
+      const m = unitText.match(/\$([\d.]+)\s*\/\s*(fl\s*oz|oz|lb|g|kg|ml|l|gal|qt|pt|cup|tbsp|tsp|ea|ct|pkg|box|can|bag|bottle|stick|roll|bar|pouch|jar|packet|sleeve|slice|piece|tube|tray|unit)/i);
       if (m) {
         pricePerUnit = parseFloat(m[1]);
-        unitType = m[2];
-        const factor = UNIT_FACTORS[unitType.toLowerCase()];
+        unitType = m[2].toLowerCase().replace(/\s+/g, '');
+        const factor = UNIT_FACTORS[unitType];
         if (factor) {
           pricePerUnit = pricePerUnit / factor;
           unitType = 'oz';

--- a/scrapers/shaws.js
+++ b/scrapers/shaws.js
@@ -1,6 +1,7 @@
 export function scrapeShaws() {
   const UNIT_FACTORS = {
     oz: 1,
+    floz: 1,
     lb: 16,
     g: 0.035274,
     kg: 35.274,
@@ -53,10 +54,11 @@ export function scrapeShaws() {
     let sizeQty = null;
     let sizeUnit = null;
     if (sizeText) {
-      const m = sizeText.match(/([\d.]+)\s*(\w+)/);
+      const m = sizeText.match(/([\d.]+)\s*(fl\s*oz|oz|lb|g|kg|ml|l|gal|qt|pt|cup|tbsp|tsp|ea|ct|pkg|box|can|bag|bottle|stick|roll|bar|pouch|jar|packet|sleeve|slice|piece|tube|tray|unit)/i);
       if (m) {
         sizeQty = parseFloat(m[1]);
-        sizeUnit = m[2];
+        sizeUnit = m[2].toLowerCase().replace(/\s+/g, '');
+        if (sizeUnit === 'floz') sizeUnit = 'oz';
       }
     }
 

--- a/scrapers/stopandshop.js
+++ b/scrapers/stopandshop.js
@@ -1,6 +1,7 @@
 export function scrapeStopAndShop() {
   const UNIT_FACTORS = {
     oz: 1,
+    floz: 1,
     lb: 16,
     g: 0.035274,
     kg: 35.274,
@@ -51,10 +52,11 @@ export function scrapeStopAndShop() {
     let unitType = null;
     if (perUnitText) {
       const clean = perUnitText.replace(/[^0-9./a-zA-Z]/g, '');
-      const match = clean.match(/([\d.]+)\/([a-zA-Z]+)/);
+      const match = clean.match(/([\d.]+)\/(fl\s*oz|oz|lb|g|kg|ml|l|gal|qt|pt|cup|tbsp|tsp|ea|ct|pkg|box|can|bag|bottle|stick|roll|bar|pouch|jar|packet|sleeve|slice|piece|tube|tray|unit)/i);
       if (match) {
         unitQty = parseFloat(match[1]);
-        unitType = match[2];
+        unitType = match[2].toLowerCase().replace(/\s+/g, '');
+        if (unitType === 'floz') unitType = 'oz';
       }
     }
 
@@ -67,10 +69,11 @@ export function scrapeStopAndShop() {
     let sizeQty = null;
     let sizeUnit = null;
     if (unitSize) {
-      const m = unitSize.match(/([\d.]+)\s*([a-zA-Z]+)/);
+      const m = unitSize.match(/([\d.]+)\s*(fl\s*oz|oz|lb|g|kg|ml|l|gal|qt|pt|cup|tbsp|tsp|ea|ct|pkg|box|can|bag|bottle|stick|roll|bar|pouch|jar|packet|sleeve|slice|piece|tube|tray|unit)/i);
       if (m) {
         sizeQty = parseFloat(m[1]);
-        sizeUnit = m[2];
+        sizeUnit = m[2].toLowerCase().replace(/\s+/g, '');
+        if (sizeUnit === 'floz') sizeUnit = 'oz';
       }
     }
 


### PR DESCRIPTION
## Summary
- improve parsing for Shaws, Stop & Shop, Hannaford and Roche Bros scrapers
- handle `fl oz` units so unit pricing displays correctly

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6850a72451848329a18fbb5e79f1214f